### PR TITLE
 Add GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/gradle-nebula.yml
+++ b/.github/workflows/gradle-nebula.yml
@@ -13,6 +13,12 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    # The GITHUB_TOKEN secret is set to an access token for the repository each time a job in a workflow begins.
+    # You should set the permissions for this access token in the workflow file to grant
+    # read access for the contents scope and write access for the packages scope.
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
 The GITHUB_TOKEN secret is set to an access token for the repository each time a job in a workflow begins.
 You should set the permissions for this access token in the workflow file to grant
 read access for the contents scope and write access for the packages scope.