### PR TITLE
Use mocked JwtDecoder instead of `.with(jwt())`

### DIFF
--- a/src/test/java/com/droidablebee/springboot/rest/endpoint/BaseEndpointTest.java
+++ b/src/test/java/com/droidablebee/springboot/rest/endpoint/BaseEndpointTest.java
@@ -1,6 +1,7 @@
 package com.droidablebee.springboot.rest.endpoint;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -8,14 +9,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.BadJwtException;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.context.WebApplicationContext;
 
 import java.io.IOException;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 
 /**
@@ -26,9 +29,6 @@ public abstract class BaseEndpointTest {
 	protected final Logger logger = LoggerFactory.getLogger(getClass());
 
 	protected static final MediaType JSON_MEDIA_TYPE = new MediaType(MediaType.APPLICATION_JSON.getType(), MediaType.APPLICATION_JSON.getSubtype());
-
-	@Autowired
-    protected WebApplicationContext webApplicationContext;
 
 	@Autowired
 	ObjectMapper objectMapper;
@@ -42,10 +42,24 @@ public abstract class BaseEndpointTest {
 	@Mock
 	protected Jwt jwt;
 
-//    protected void setup() throws Exception {
-//
-//    	this.mockMvc = webAppContextSetup(webApplicationContext).build();
-//    }
+	/**
+	 * @BeforeEach methods are inherited from superclasses as long as they are not overridden.
+	 * Hence, the different method name.
+	 */
+	@BeforeEach
+	public void setupBase() {
+
+		when(jwtDecoder.decode(anyString())).thenAnswer(
+				invocation -> {
+					String token = invocation.getArgument(0);
+					if ("invalid".equals(token)) {
+						throw new BadJwtException("Token is invalid");
+					} else {
+						return jwt;
+					}
+				}
+		);
+	}
     
 	/**
 	 * Returns json representation of the object.

--- a/src/test/java/com/droidablebee/springboot/rest/endpoint/BaseEndpointTest.java
+++ b/src/test/java/com/droidablebee/springboot/rest/endpoint/BaseEndpointTest.java
@@ -1,11 +1,15 @@
 package com.droidablebee.springboot.rest.endpoint;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.mockito.Mock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
@@ -31,6 +35,12 @@ public abstract class BaseEndpointTest {
 
 	@Autowired
 	protected MockMvc mockMvc;
+
+	@MockBean
+	protected JwtDecoder jwtDecoder;
+
+	@Mock
+	protected Jwt jwt;
 
 //    protected void setup() throws Exception {
 //

--- a/src/test/java/com/droidablebee/springboot/rest/endpoint/PersonEndpointStubbedTest.java
+++ b/src/test/java/com/droidablebee/springboot/rest/endpoint/PersonEndpointStubbedTest.java
@@ -28,16 +28,21 @@ public class PersonEndpointStubbedTest extends BaseEndpointTest {
 	private Person testPerson;
 
     @BeforeEach
-    public void setup() throws Exception {
+    public void setup() {
 
     	testPerson = new Person(1L, "Jack", "Bauer");
 		when(personService.findOne(1L)).thenReturn(testPerson);
+
+        when(jwt.hasClaim("scope")).thenReturn(true);
+        when(jwt.getClaim("scope")).thenReturn(PERSON_READ_PERMISSION);
     }
 
     @Test
     public void getPersonById() throws Exception {
 
-    	mockMvc.perform(get("/v1/person/{id}", 1).with(jwtWithScope(PERSON_READ_PERMISSION)))
+    	mockMvc.perform(get("/v1/person/{id}", 1)
+                        .header("Authorization", "Bearer valid")
+                )
     	.andDo(print())
     	.andExpect(status().isOk())
     	.andExpect(content().contentType(JSON_MEDIA_TYPE))
@@ -53,7 +58,9 @@ public class PersonEndpointStubbedTest extends BaseEndpointTest {
         String message = "Failed to get person by id";
         when(personService.findOne(1L)).thenThrow(new RuntimeException(message));
 
-        mockMvc.perform(get("/v1/person/{id}", 1).with(jwtWithScope(PERSON_READ_PERMISSION)))
+        mockMvc.perform(get("/v1/person/{id}", 1)
+                        .header("Authorization", "Bearer valid")
+                )
                 .andDo(print())
                 .andExpect(status().is5xxServerError())
                 .andExpect(content().contentType(JSON_MEDIA_TYPE))

--- a/src/test/java/com/droidablebee/springboot/rest/endpoint/PersonEndpointTest.java
+++ b/src/test/java/com/droidablebee/springboot/rest/endpoint/PersonEndpointTest.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 import static com.droidablebee.springboot.rest.endpoint.PersonEndpoint.PERSON_READ_PERMISSION;
@@ -327,7 +328,7 @@ public class PersonEndpointTest extends BaseEndpointTest {
     public void createPerson() throws Exception {
 
 		when(jwt.hasClaim("scope")).thenReturn(true);
-		when(jwt.getClaim("scope")).thenReturn(PERSON_READ_PERMISSION +" "+ PERSON_WRITE_PERMISSION);
+		when(jwt.getClaim("scope")).thenReturn(List.of(PERSON_READ_PERMISSION, PERSON_WRITE_PERMISSION));
 
     	Person person = createPerson("first", "last");
     	person.setMiddleName("middleName");

--- a/src/test/java/com/droidablebee/springboot/rest/endpoint/PersonEndpointTest.java
+++ b/src/test/java/com/droidablebee/springboot/rest/endpoint/PersonEndpointTest.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.security.oauth2.jwt.BadJwtException;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -24,7 +25,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -39,15 +41,15 @@ public class PersonEndpointTest extends BaseEndpointTest {
 
 	@Autowired
 	private EntityManager entityManager;
-	
+
 	@Autowired
 	private PersonService personService;
-	
+
 	private Person testPerson;
 	private long timestamp;
-	
+
     @BeforeEach
-    public void setup() throws Exception {
+    public void setup() {
 
     	timestamp = new Date().getTime();
 
@@ -61,13 +63,24 @@ public class PersonEndpointTest extends BaseEndpointTest {
     	Page<Person> persons = personService.findAll(PageRequest.of(0, PersonEndpoint.DEFAULT_PAGE_SIZE));
 		assertNotNull(persons);
 		assertEquals(5L, persons.getTotalElements());
-		
+
 		testPerson = persons.getContent().get(0);
-		
+
 		//refresh entity with any changes that have been done during persistence including Hibernate conversion
 		//example: java.util.Date field is injected with either with java.sql.Date (if @Temporal(TemporalType.DATE) is used)
 		//or java.sql.Timestamp
 		entityManager.refresh(testPerson);
+
+		when(jwtDecoder.decode(anyString())).thenAnswer(
+			invocation -> {
+				String token = invocation.getArgument(0);
+				if ("invalid".equals(token)) {
+					throw new BadJwtException("Token is invalid");
+				} else {
+					return jwt;
+				}
+			}
+		);
     }
 
 	@Test
@@ -81,10 +94,24 @@ public class PersonEndpointTest extends BaseEndpointTest {
 	}
 
 	@Test
+	public void getPersonByIdUnauthorizedInvalidToken() throws Exception {
+		Long id = testPerson.getId();
+
+		mockMvc.perform(get("/v1/person/{id}", id)
+						.header("Authorization", "Bearer invalid")
+				)
+				.andDo(print())
+				.andExpect(status().isUnauthorized())
+		;
+	}
+
+	@Test
 	public void getPersonByIdForbiddenInvalidScope() throws Exception {
 		Long id = testPerson.getId();
 
-		mockMvc.perform(get("/v1/person/{id}", id).with(jwt()))
+		mockMvc.perform(get("/v1/person/{id}", id)
+						.header("Authorization", "Bearer valid")
+				)
 				.andDo(print())
 				.andExpect(status().isForbidden())
 		;
@@ -93,8 +120,13 @@ public class PersonEndpointTest extends BaseEndpointTest {
 	@Test
     public void getPersonById() throws Exception {
     	Long id = testPerson.getId();
-    	
-    	mockMvc.perform(get("/v1/person/{id}", id).with(jwtWithScope(PERSON_READ_PERMISSION)))
+
+		when(jwt.hasClaim("scope")).thenReturn(true);
+		when(jwt.getClaim("scope")).thenReturn(PERSON_READ_PERMISSION);
+
+    	mockMvc.perform(get("/v1/person/{id}", id)
+						.header("Authorization", "Bearer valid")
+				)
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(JSON_MEDIA_TYPE))
@@ -110,7 +142,12 @@ public class PersonEndpointTest extends BaseEndpointTest {
 
 		Page<Person> persons = personService.findAll(PageRequest.of(0, PersonEndpoint.DEFAULT_PAGE_SIZE));
 
-    	mockMvc.perform(get("/v1/persons").with(jwtWithScope(PERSON_READ_PERMISSION)))
+		when(jwt.hasClaim("scope")).thenReturn(true);
+		when(jwt.getClaim("scope")).thenReturn(PERSON_READ_PERMISSION);
+
+    	mockMvc.perform(get("/v1/persons")
+						.header("Authorization", "Bearer valid")
+				)
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andExpect(content().contentType(JSON_MEDIA_TYPE))
@@ -119,20 +156,22 @@ public class PersonEndpointTest extends BaseEndpointTest {
     }
 
     /**
-     * Test JSR-303 bean validation. 
+     * Test JSR-303 bean validation.
      */
     @Test
     public void createPersonValidationErrorLastName() throws Exception {
-    	
+
     	//person with missing last name
     	Person person = createPerson("first", null);
     	person.setMiddleName("middle");
     	String content = json(person);
 		mockMvc.perform(
-				put("/v1/person").with(jwt())
-				.accept(JSON_MEDIA_TYPE)
-				.content(content)
-				.contentType(JSON_MEDIA_TYPE))
+				put("/v1/person")
+                        .header("Authorization", "Bearer valid")
+                        .accept(JSON_MEDIA_TYPE)
+                        .content(content)
+                        .contentType(JSON_MEDIA_TYPE)
+                )
 		.andDo(print())
 		.andExpect(status().isBadRequest())
 		.andExpect(content().contentType(JSON_MEDIA_TYPE))
@@ -143,16 +182,17 @@ public class PersonEndpointTest extends BaseEndpointTest {
     }
 
     /**
-     * Test custom bean validation. 
+     * Test custom bean validation.
      */
     @Test
     public void createPersonValidationErrorMiddleName() throws Exception {
-    	
+
     	//person with missing middle name - custom validation
     	Person person = createPerson("first", "last");
     	String content = json(person);
 		mockMvc.perform(
-				put("/v1/person").with(jwt())
+				put("/v1/person")
+				.header("Authorization", "Bearer valid")
 				.accept(JSON_MEDIA_TYPE)
 				.content(content)
 				.contentType(JSON_MEDIA_TYPE))
@@ -166,11 +206,11 @@ public class PersonEndpointTest extends BaseEndpointTest {
     }
 
     /**
-     * Test JSR-303 bean object graph validation with nested entities. 
+     * Test JSR-303 bean object graph validation with nested entities.
      */
     @Test
     public void createPersonValidationAddress() throws Exception {
-    	
+
     	Person person = createPerson("first", "last");
     	person.setMiddleName("middle");
     	person.addAddress(new Address("line1", "city", "state", "zip"));
@@ -178,7 +218,8 @@ public class PersonEndpointTest extends BaseEndpointTest {
 
     	String content = json(person);
 		mockMvc.perform(
-				put("/v1/person").with(jwt())
+				put("/v1/person")
+				.header("Authorization", "Bearer valid")
 				.accept(JSON_MEDIA_TYPE)
 				.content(content)
 				.contentType(JSON_MEDIA_TYPE))
@@ -195,13 +236,17 @@ public class PersonEndpointTest extends BaseEndpointTest {
 
     @Test
     public void createPersonValidationToken() throws Exception {
-    	
-    	Person person = createPerson("first", "last");
+
+		when(jwt.hasClaim("scope")).thenReturn(true);
+		when(jwt.getClaim("scope")).thenReturn(PERSON_WRITE_PERMISSION);
+
+		Person person = createPerson("first", "last");
     	person.setMiddleName("middle");
-    	
+
     	String content = json(person);
     	mockMvc.perform(
-    			put("/v1/person").with(jwtWithScope(PERSON_WRITE_PERMISSION))
+    			put("/v1/person")
+				.header("Authorization", "Bearer valid")
     			.header(PersonEndpoint.HEADER_USER_ID, UUID.randomUUID())
     			.header(PersonEndpoint.HEADER_TOKEN, "1") //invalid token
     			.accept(JSON_MEDIA_TYPE)
@@ -214,16 +259,17 @@ public class PersonEndpointTest extends BaseEndpointTest {
     	.andExpect(jsonPath("$.[?(@.field == 'add.token')].message", hasItem("token size 2-40")))
     	;
     }
-    
+
     @Test
     public void createPersonValidationUserId() throws Exception {
-    	
+
     	Person person = createPerson("first", "last");
     	person.setMiddleName("middle");
-    	
+
     	String content = json(person);
     	mockMvc.perform(
-    			put("/v1/person").with(jwt())
+    			put("/v1/person")
+				.header("Authorization", "Bearer valid")
     			.accept(JSON_MEDIA_TYPE)
     			.content(content)
     			.contentType(JSON_MEDIA_TYPE))
@@ -257,13 +303,17 @@ public class PersonEndpointTest extends BaseEndpointTest {
 	@Test
 	public void createPersonForbiddenInvalidScope() throws Exception {
 
+		when(jwt.hasClaim("scope")).thenReturn(true);
+		when(jwt.getClaim("scope")).thenReturn(PERSON_READ_PERMISSION);
+
 		Person person = createPerson("first", "last");
 		person.setMiddleName("middleName");
 
 		String content = json(person);
 
 		mockMvc.perform(
-				put("/v1/person").with(jwtWithScope(PERSON_READ_PERMISSION))
+				put("/v1/person")
+						.header("Authorization", "Bearer valid")
 						.header(PersonEndpoint.HEADER_USER_ID, UUID.randomUUID())
 						.accept(JSON_MEDIA_TYPE)
 						.content(content)
@@ -275,14 +325,18 @@ public class PersonEndpointTest extends BaseEndpointTest {
 
 	@Test
     public void createPerson() throws Exception {
-    	
+
+		when(jwt.hasClaim("scope")).thenReturn(true);
+		when(jwt.getClaim("scope")).thenReturn(PERSON_READ_PERMISSION +" "+ PERSON_WRITE_PERMISSION);
+
     	Person person = createPerson("first", "last");
     	person.setMiddleName("middleName");
 
     	String content = json(person);
-		
+
     	mockMvc.perform(
-				put("/v1/person").with(jwtWithScope(PERSON_READ_PERMISSION +" "+ PERSON_WRITE_PERMISSION))
+				put("/v1/person")
+				.header("Authorization", "Bearer valid")
     			.header(PersonEndpoint.HEADER_USER_ID, UUID.randomUUID())
 				.accept(JSON_MEDIA_TYPE)
 				.content(content)
@@ -299,14 +353,18 @@ public class PersonEndpointTest extends BaseEndpointTest {
 
     @Test
     public void createPersonWithDateVerification() throws Exception {
-    	
+
+		when(jwt.hasClaim("scope")).thenReturn(true);
+		when(jwt.getClaim("scope")).thenReturn(PERSON_WRITE_PERMISSION);
+
     	Person person = createPerson("first", "last");
     	person.setMiddleName("middleName");
-    	
+
     	String content = json(person);
-    	
+
     	mockMvc.perform(
-    			put("/v1/person").with(jwtWithScope(PERSON_WRITE_PERMISSION))
+    			put("/v1/person")
+				.header("Authorization", "Bearer valid")
     			.header(PersonEndpoint.HEADER_USER_ID, UUID.randomUUID())
     			.accept(JSON_MEDIA_TYPE)
     			.content(content)
@@ -318,19 +376,20 @@ public class PersonEndpointTest extends BaseEndpointTest {
     	.andExpect(jsonPath("$.dateOfBirth", isA(Number.class)))
     	.andExpect(jsonPath("$.dateOfBirth", is(person.getDateOfBirth().getTime())))
     	;
-    	
+
     }
 
     @Test
     public void requestBodyValidationInvalidJsonValue() throws Exception {
-    	
+
     	testPerson.setGender(Person.Gender.M);
     	String content = json(testPerson);
     	//payload with invalid gender
     	content = content.replaceFirst("(\"gender\":\")(M)(\")", "$1Q$3");
 
     	mockMvc.perform(
-    			put("/v1/person").with(jwt())
+    			put("/v1/person")
+				.header("Authorization", "Bearer valid")
     			.header(PersonEndpoint.HEADER_USER_ID, UUID.randomUUID())
     			.accept(JSON_MEDIA_TYPE)
     			.content(content)
@@ -341,13 +400,14 @@ public class PersonEndpointTest extends BaseEndpointTest {
     	.andExpect(jsonPath("$.message", containsString("Cannot deserialize value of type `com.droidablebee.springboot.rest.domain.Person$Gender`")))
     	;
     }
-    
+
     @Test
     public void requestBodyValidationInvalidJson() throws Exception {
-    	
+
     	String content = json("not valid json");
     	mockMvc.perform(
-    			put("/v1/person").with(jwt())
+    			put("/v1/person")
+				.header("Authorization", "Bearer valid")
     			.header(PersonEndpoint.HEADER_USER_ID, UUID.randomUUID())
     			.accept(JSON_MEDIA_TYPE)
     			.content(content)
@@ -361,11 +421,12 @@ public class PersonEndpointTest extends BaseEndpointTest {
 
     @Test
     public void handleHttpRequestMethodNotSupportedException() throws Exception {
-    	
+
     	String content = json(testPerson);
-    	
+
     	mockMvc.perform(
-    			delete("/v1/person").with(jwt()) //not supported method
+    			delete("/v1/person") //not supported method
+				.header("Authorization", "Bearer valid")
     			.header(PersonEndpoint.HEADER_USER_ID, UUID.randomUUID())
     			.accept(JSON_MEDIA_TYPE)
     			.content(content)

--- a/src/test/java/com/droidablebee/springboot/rest/endpoint/PersonEndpointTest.java
+++ b/src/test/java/com/droidablebee/springboot/rest/endpoint/PersonEndpointTest.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.security.oauth2.jwt.BadJwtException;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -26,7 +25,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -71,17 +69,6 @@ public class PersonEndpointTest extends BaseEndpointTest {
 		//example: java.util.Date field is injected with either with java.sql.Date (if @Temporal(TemporalType.DATE) is used)
 		//or java.sql.Timestamp
 		entityManager.refresh(testPerson);
-
-		when(jwtDecoder.decode(anyString())).thenAnswer(
-			invocation -> {
-				String token = invocation.getArgument(0);
-				if ("invalid".equals(token)) {
-					throw new BadJwtException("Token is invalid");
-				} else {
-					return jwt;
-				}
-			}
-		);
     }
 
 	@Test


### PR DESCRIPTION
### How `.with(jwt())` works.

> Establish a SecurityContext that has a JwtAuthenticationToken for the Authentication and a Jwt for the Authentication.getPrincipal(). All details are declarative and do not require the JWT to be valid. The support works by associating the authentication to the HttpServletRequest.

It actually makes that mocked SecurityContext available in `SecurityContextPersistenceFilter#doFilter(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse, javax.servlet.FilterChain)`.

As the result, when `BearerTokenAuthenticationFilter#doFilterInternal` is invoked, it does not do much since token is null.

But since SecurityContext has been established, the 200 is returned even though all the JWT validation is skipped.

### Advantages of using a mocked JwtDecoder are
 * standard Authorization header is used to pass a mocked bearer token
 * the same security filter `BearerTokenAuthenticationFilter` is used to process the mocked bearer token
 * mocked JwtDecoder can be used to test more token scenarios including invalid token, verification of the audience, etc

 Example:
 `.with(jwtWithScope("read"))`
 is equivalent to
 ```
         jwt.hasClaim("scope") >> true
         jwt.getClaim("scope") >> ["read"]
```