### PR TITLE
Add scheduled release to pick up dependabot automerged commits

### DIFF
--- a/.github/workflows/gradle-nebula.yml
+++ b/.github/workflows/gradle-nebula.yml
@@ -9,7 +9,16 @@ on:
     branches:
       - master
       - release/*
+  schedule:
+    - cron: '0 */6 * * *'
+
 jobs:
+
+  find-untagged-commit:
+    name: find untagged commit
+    uses: pavelfomin/shared-workflows/.github/workflows/find-untagged-commit.yml@v0
+    secrets: inherit
+
   build:
 
     runs-on: ubuntu-latest
@@ -21,7 +30,7 @@ jobs:
       packages: write
       pull-requests: write
       checks: write
-
+    if: ${{ needs.find-untagged-commit.outputs.hash || github.event_name != 'schedule' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
When auto-merge completes, the merge commit pushed to master is attributed to GITHUB_TOKEN. GitHub deliberately suppresses workflow triggering for pushes made by GITHUB_TOKEN to
  prevent infinite recursive runs. So your gradle-nebula.yml (on: push: branches: [master]) — which does the publish + final tag + scripts/deploy-latest.sh — never fires for those
  merges.

  GitHub's wording:

> "When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN ... will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs."

  Docs: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow